### PR TITLE
All preconditions are to be met before moving host

### DIFF
--- a/lib/cluster.js
+++ b/lib/cluster.js
@@ -213,18 +213,25 @@ Cluster.prototype.moveHost = function(host, newname) {
     var self     = this,
         previous = host.name();
 
-    // First rename the host itself
-    return host.rename(newname)
-    // Change the references to this host in the cluster
-    .then(function() {
-        return self.read();
-    })
-    .then(function(config) {
+    return return self.read()
+
+    // Frist check if the host exists in the cluster
+    .then(function (config) {
         var index = lookupHostIndex(config, previous);
         if (index === -1) {
-            return Promise.reject('Host does not exists in this cluster');
+            return Promise.reject('Host does not exist in this cluster');
         }
+        return config;
+    }).
 
+    // Rename the host itself
+    .then(function(config) {
+        host.rename(newname);
+        return config;
+    })
+
+    // Change the references to this host in the cluster
+    .then(function(config) {
         // Replace "include" directive in cluster playbook
         config[index] = {
             include: path.relative(self.dir, host.path())

--- a/lib/cluster.js
+++ b/lib/cluster.js
@@ -213,7 +213,7 @@ Cluster.prototype.moveHost = function(host, newname) {
     var self     = this,
         previous = host.name();
 
-    return return self.read()
+    return self.read()
 
     // Frist check if the host exists in the cluster
     .then(function (config) {
@@ -221,22 +221,21 @@ Cluster.prototype.moveHost = function(host, newname) {
         if (index === -1) {
             return Promise.reject('Host does not exist in this cluster');
         }
-        return config;
-    }).
 
-    // Rename the host itself
-    .then(function(config) {
-        host.rename(newname);
-        return config;
+	// Rename the host
+        return host.rename(newname)
+        // Change the references to this host in the cluster
+        .then(function () {
+            // Replace "include" directive in cluster playbook
+            config[index] = {
+                include: path.relative(self.dir, host.path())
+            };
+            return config;
+        });
     })
 
-    // Change the references to this host in the cluster
+    // Write the configuration
     .then(function(config) {
-        // Replace "include" directive in cluster playbook
-        config[index] = {
-            include: path.relative(self.dir, host.path())
-        };
-
         return self.write(config);
     })
 

--- a/lib/cluster.js
+++ b/lib/cluster.js
@@ -214,15 +214,15 @@ Cluster.prototype.moveHost = function(host, newname) {
         previous = host.name();
 
     return self.read()
-
-    // Frist check if the host exists in the cluster
     .then(function (config) {
+
+        // First check if the host exists in the cluster
         var index = lookupHostIndex(config, previous);
         if (index === -1) {
             return Promise.reject('Host does not exist in this cluster');
         }
 
-	// Rename the host
+        // Rename the host
         return host.rename(newname)
         // Change the references to this host in the cluster
         .then(function () {


### PR DESCRIPTION
From what I understand when renaming a host, we were first renaming the host file, and checking afterwards if the host exists in the cluster configuration.

I inverted the order in which this was done.